### PR TITLE
Phone ringtone setting for Multi SIM device

### DIFF
--- a/target/product/full_base.mk
+++ b/target/product/full_base.mk
@@ -42,6 +42,8 @@ PRODUCT_PACKAGES += \
     netutils-wrapper-1.0
 
 # Additional settings used in all AOSP builds
+#   ro.config.ringtone supports Multi SIM Device configuration.
+#   Vendors can customize it by spliting the ringtone file for each slot with ",".
 #PRODUCT_PROPERTY_OVERRIDES := \
 #    ro.config.ringtone=Ring_Synth_04.ogg \
 #    ro.config.notification_sound=pixiedust.ogg


### PR DESCRIPTION
"ro.config.ringtone" can support Multi SIM device by spliting the
ringtone for each slot with ",". So add description for it.

Bug: 118735436
Test: Manual
Change-Id: I298024f500aa839ebfc15a3ee51e2f452c23b290